### PR TITLE
Recreate tmp folder if it does not exist

### DIFF
--- a/webapp/start.sh
+++ b/webapp/start.sh
@@ -41,8 +41,7 @@ for i in /etc/kopano/webapp/*.dist /etc/kopano/webapp/.[^.]*.dist; do
 done
 
 # Ensure directories exist
-mkdir -p /run/sessions /tmp/webapp
-mkdir -p /var/lib/kopano-webapp/tmp
+mkdir -p /run/sessions /tmp/webapp /var/lib/kopano-webapp/tmp
 
 phpversion=$(dpkg-query --showformat='${Version}' --show php7-mapi)
 echo "Using PHP-Mapi: $phpversion"
@@ -72,8 +71,7 @@ for setting in $(compgen -A variable KCCONF_WEBAPPPLUGIN_); do
 done
 
 echo "Ensure config ownership"
-chown -R www-data:www-data /run/sessions /tmp/webapp
-chown -R www-data:www-data /var/lib/kopano-webapp/tmp
+chown -R www-data:www-data /run/sessions /tmp/webapp /var/lib/kopano-webapp/tmp
 
 # services need to be aware of the machine-id
 dockerize \

--- a/webapp/start.sh
+++ b/webapp/start.sh
@@ -42,6 +42,7 @@ done
 
 # Ensure directories exist
 mkdir -p /run/sessions /tmp/webapp
+mkdir -p /var/lib/kopano-webapp/tmp
 
 phpversion=$(dpkg-query --showformat='${Version}' --show php7-mapi)
 echo "Using PHP-Mapi: $phpversion"
@@ -72,6 +73,7 @@ done
 
 echo "Ensure config ownership"
 chown -R www-data:www-data /run/sessions /tmp/webapp
+chown -R www-data:www-data /var/lib/kopano-webapp/tmp
 
 # services need to be aware of the machine-id
 dockerize \


### PR DESCRIPTION
In case one uses a host volume for /var/lib/kopano-webapp/, the "tmp" folder is not created automatically which leads to an error when trying to view webapp.
This change ensures that the tmp folder exists.